### PR TITLE
Allow passing of "readied" credentials so can utilise CognitoIdentityCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ new BunyanKinesis({
 
 `streamName` is the name of the Kinesis Stream.
 
+`credentials` can be passed in instread of using ACCCESS_KEY / SECET. Useful for using already authenticated e.g. with CognitoIdentityCredentials.
+
+```javascript
+const AWS = require('aws-sdk')
+const BunyanKinesis = require('bunyan-kinesis')
+
+AWS.config.region = 'AWS_REGION';
+AWS.config.credentials = new CognitoIdentityCredentials({
+  IdentityPoolId: 'IDENTITY_POOL_ID'
+});
+
+AWS.config.credentials.get(err => {
+  // set credentials directly...
+  new BunyanKinesis({
+    credentials:     AWS.config.credentials,
+    region:          'AWS_REGION',
+    streamName:      'MyKinesisStream',
+    partitionKey:    'MyApp'
+  });
+})
+```
+
 **Note**: Amazon Credentials are not required. It will either use the environment variables, `~/.aws/credentials` or roles as every other aws sdk.
 
 ## License

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function KinesisStream (params) {
     this._queueWait = setTimeout(this._sendEntries.bind(this), 5 * 1000);
   }
 
-  this._kinesis = new AWS.Kinesis(_.pick(params, ['accessKeyId', 'secretAccessKey', 'region']));
+  this._kinesis = new AWS.Kinesis(_.pick(params, ['accessKeyId', 'secretAccessKey', 'region', 'credentials']));
 }
 
 util.inherits(KinesisStream, stream.Writable);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bunyan-kinesis",
   "description": "A bunyan stream for kinesis.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "repository": {
     "url": "git://github.com/auth0/bunyan-kinesis.git"


### PR DESCRIPTION
Currently implementation relies on default AWS credentials. 
However, from client side code its often useful to allow logging use anonymous users with credentials obtained via CognitoIdentityCredentials.

This branch allows setting the fully formed credentials object to avoid doing the default authentication flow. 

I've updated the docs appropriately. 

I see this project is depreciated and to now use aws-kinesis-writable instead. I have however had a little difficultly currently getting that library to work in browser due to some nodejs specific libraries it's using under the hood. I'm sure its not insurmountable and I will be adding the ability to use CognitoIdentityCredentials to that once I can do a work around on its dependancies. 




